### PR TITLE
version 0.2.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyutils"
-version = "0.2.10"
+version = "0.2.11"
 authors = [{ name = "Jylpah", email = "jylpah@gmail.com" }]
 description = "Misc Python utils and classes"
 readme = "README.md"

--- a/src/pyutils/jsonexportable.py
+++ b/src/pyutils/jsonexportable.py
@@ -137,7 +137,7 @@ class JSONExportable(BaseModel):
             async with open(filename, "r") as f:
                 return cls.parse_raw(await f.read())
         except Exception as err:
-            error(f"Error reading replay: {err}")
+            debug(f"Error reading file: {err}")
         return None
 
     @classmethod
@@ -146,7 +146,7 @@ class JSONExportable(BaseModel):
         try:
             return cls.parse_raw(content)
         except ValidationError as err:
-            error(f"Could not parse {type(cls)} from JSON: {err}")
+            debug(f"Could not parse {type(cls)} from JSON: {err}")
         return None
 
     @classmethod


### PR DESCRIPTION
- `JSONExportable()`: change error() messages to debug():
  - open_json()
  - parser_str()