### PR TITLE
aiohttp>=3.9.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 dependencies = [
     "aiofiles>=23.1.0",
-    "aiohttp>=3.8.5",
+    "aiohttp~=3.9.1",
     "Brotli>=1.1.0",
     "aiodns>=3.0.0",
     "aioconsole>=0.6.1",


### PR DESCRIPTION
the older versions fail on Python 3.12