### PR TITLE
version 1.2.0: ThrottledClientSession(): re_filter init param removed

### DIFF
--- a/.github/workflows/python-package-macos-win.yml
+++ b/.github/workflows/python-package-macos-win.yml
@@ -43,7 +43,7 @@ jobs:
         mypy src
     - name: Test with pytest
       run: |
-        pytest --cov .
+        pytest --cov=src tests
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3
       env:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -37,7 +37,7 @@ jobs:
         mypy src
     - name: Test with pytest
       run: |
-        pytest --cov .
+        pytest --cov=src tests
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3
       env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyutils"
-version = "1.1.0"
+version = "1.2.0"
 authors = [{ name = "Jylpah", email = "jylpah@gmail.com" }]
 description = "Misc Python utils and classes"
 readme = "README.md"
@@ -65,6 +65,7 @@ mypy_path = ['src']
 include = ["pyproject.toml", "src/**/*.py", "tests/**/*.py"]
 indent-width = 4
 extend-include = ["*.ipynb"]
+extend-exclude = [".venv", ".vscode" ] 
 fixable = ["ALL"]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,9 @@ extend-include = ["*.ipynb"]
 fixable = ["ALL"]
 
 [tool.pytest.ini_options]
-minversion = "7.0"
+minversion = "7.4"
 addopts = "-v --cov=src"
+pythonpath = "src" # avoid import path append in test files
 filterwarnings = [
     'ignore:Inheritance class ThrottledClientSession from ClientSession is discouraged:DeprecationWarning',
 ]

--- a/src/pyutils/__init__.py
+++ b/src/pyutils/__init__.py
@@ -7,7 +7,10 @@ from .eventcounter import EventCounter as EventCounter
 from .filequeue import FileQueue as FileQueue
 from .iterablequeue import IterableQueue as IterableQueue, QueueDone as QueueDone
 from .multilevelformatter import MultilevelFormatter as MultilevelFormatter
-from .throttledclientsession import ThrottledClientSession as ThrottledClientSession
+from .throttledclientsession import (
+    ThrottledClientSession as ThrottledClientSession,
+    UrlFilter as UrlFilter,
+)
 from .urlqueue import UrlQueue as UrlQueue
 from .utils import (
     Countable as Countable,

--- a/src/pyutils/bucketmapper.py
+++ b/src/pyutils/bucketmapper.py
@@ -4,65 +4,65 @@ from typing import TypeVar, Generic, Optional
 import logging
 
 # Setup logging
-logger	= logging.getLogger()
-error 	= logger.error
-message	= logger.warning
-verbose	= logger.info
-debug	= logger.debug
+logger = logging.getLogger()
+error = logger.error
+message = logger.warning
+verbose = logger.info
+debug = logger.debug
 
 T = TypeVar("T")
 
 ###############################################################################
 #
-## WARNING: This class does not perform as well as 
+## WARNING: This class does not perform as well as
 #  sortedcollections.NearestDict()
-# 
+#
 ###############################################################################
 
+
 class BucketMapper(Generic[T]):
-	"""BucketMapper() is a generic class for mapping object based on a 
-		numeric, discrete key and retrieving objects by value that is 
-		less that the key. see python bisect module"""
-	
-	def __init__(self, attr: str):
-		self._key = attrgetter(attr)
-		self._data : list[T] = list()
+    """BucketMapper() is a generic class for mapping object based on a
+    numeric, discrete key and retrieving objects by value that is
+    less that the key. see python bisect module"""
 
+    def __init__(self, attr: str):
+        self._key = attrgetter(attr)
+        self._data: list[T] = list()
 
-	def insert(self, item : T) -> None:
-		insort(self._data, item, key=self._key)
-		return None
-	
+    def insert(self, item: T) -> None:
+        insort(self._data, item, key=self._key)
+        return None
 
-	def get(self, 
-	 		key: int | float, 
-			shift: int = 0,
-			) -> Optional[T]:
-		"""Get item that has the smallest key larger than key. Use shift to offset"""
-		try:
-			return self._data[bisect(self._data, key, key=self._key) + shift]
-		except IndexError as err:
-			error(f'key={key} is outside of the key range: {err}')
-		except Exception as err:
-			debug(f'Unknown error getting the value for key={key}: {err}')
-		return None
+    def get(
+        self,
+        key: int | float,
+        shift: int = 0,
+    ) -> Optional[T]:
+        """Get item that has the smallest key larger than key. Use shift to offset"""
+        try:
+            return self._data[bisect(self._data, key, key=self._key) + shift]
+        except IndexError as err:
+            error(f"key={key} is outside of the key range: {err}")
+        except Exception as err:
+            debug(f"Unknown error getting the value for key={key}: {err}")
+        return None
 
+    def pop(
+        self,
+        item: T | None = None,
+        key: Optional[int | float] = None,
+        shift: int = 0,
+    ) -> Optional[T]:
+        try:
+            if item is not None:
+                key = self._key(item)
+            if key is not None:
+                return self._data.pop(
+                    bisect_left(self._data, key, key=self._key) + shift
+                )
+        except Exception as err:
+            error(f"{err}")
+        return None
 
-	def pop(self, 
-	 		item : T|None = None, 
-	 		key : Optional[int|float] = None, 
-			shift: int = 0,
-			) -> Optional[T]:
-		try:
-			if item is not None:
-				key = self._key(item)
-			if key is not None:
-				return self._data.pop(bisect_left(self._data, key, key=self._key) + shift)
-		except Exception as err:
-			error(f'{err}')
-		return None
-	
-
-	def list(self) -> list[T]:
-		return self._data
-		
+    def list(self) -> list[T]:
+        return self._data

--- a/src/pyutils/counterqueue.py
+++ b/src/pyutils/counterqueue.py
@@ -3,65 +3,61 @@ from typing import TypeVar
 from .utils import Countable
 import logging
 
-logger 	= logging.getLogger()
-error 	= logger.error
-message	= logger.warning
-verbose	= logger.info
-debug	= logger.debug
+logger = logging.getLogger()
+error = logger.error
+message = logger.warning
+verbose = logger.info
+debug = logger.debug
 
 ###########################################
-# 
-# class CounterQueue  
+#
+# class CounterQueue
 #
 ###########################################
-T = TypeVar('T')
+T = TypeVar("T")
+
 
 class CounterQueue(Queue[T], Countable):
-	_counter 	 : int
-	_count_items : bool
-	_batch 		 : int
+    _counter: int
+    _count_items: bool
+    _batch: int
 
-	def __init__(self, *args, 
-	      		count_items : bool = True, 
-				batch: int = 1, 
-				**kwargs) -> None:
-		super().__init__(*args, **kwargs)
-		self._counter = 0
-		self._count_items = count_items
-		self._batch = batch
+    def __init__(
+        self, *args, count_items: bool = True, batch: int = 1, **kwargs
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._counter = 0
+        self._count_items = count_items
+        self._batch = batch
 
-	def task_done(self) -> None:
-		super().task_done()
-		if self._count_items:
-			self._counter += 1
-		return None
+    def task_done(self) -> None:
+        super().task_done()
+        if self._count_items:
+            self._counter += 1
+        return None
 
+    @property
+    def count(self) -> int:
+        """Return number of completed tasks"""
+        return self._counter * self._batch
 
-	@property
-	def count(self) -> int:
-		"""Return number of completed tasks"""
-		return self._counter * self._batch
+    @property
+    def count_items(self) -> bool:
+        """Whether or not count items"""
+        return self._count_items
 
-
-	@property
-	def count_items(self) -> bool:
-		"""Whether or not count items"""
-		return self._count_items
 
 class QCounter:
-	def __init__(self, Q : Queue[int]):
-		self._count = 0
-		self._Q : Queue[int]= Q
+    def __init__(self, Q: Queue[int]):
+        self._count = 0
+        self._Q: Queue[int] = Q
 
+    @property
+    def count(self) -> int:
+        return self._count
 
-	@property
-	def count(self) -> int:
-		return self._count	
-
-
-	async def start(self) -> None:
-		"""Read and count items from Q"""
-		while True:
-			self._count += await self._Q.get()
-			self._Q.task_done()
-			
+    async def start(self) -> None:
+        """Read and count items from Q"""
+        while True:
+            self._count += await self._Q.get()
+            self._Q.task_done()

--- a/src/pyutils/throttledclientsession.py
+++ b/src/pyutils/throttledclientsession.py
@@ -42,6 +42,9 @@ def is_HTTP_method(method: Any) -> TypeGuard[HTTPmethod]:
     return isinstance(method, str) and method in get_args(HTTPmethod)
 
 
+UrlFilter = Union[str, re.Pattern]
+
+
 class ThrottledClientSession(ClientSession):
     """
     Rate-throttled client session class inherited from aiohttp.ClientSession)
@@ -54,7 +57,7 @@ class ThrottledClientSession(ClientSession):
     def __init__(
         self,
         rate_limit: float = 0,
-        filters: list[str | Tuple[Optional[str], str]] = list(),
+        filters: list[UrlFilter | Tuple[Optional[str], UrlFilter]] = list(),
         limit_filtered: bool = False,  # whether 'filters' allow/whitelists URLs
         re_filter: bool = False,  # use regexp filters
         *args,
@@ -77,12 +80,9 @@ class ThrottledClientSession(ClientSession):
         self._count: int = 0
         self._errors: int = 0
         self._limit_filtered: bool = limit_filtered
-        self._re_filter: bool = re_filter
-        self._filters: list[
-            Tuple[Optional[HTTPmethod], Union[str, re.Pattern]]
-        ] = list()
+        self._filters: list[Tuple[Optional[HTTPmethod], UrlFilter]] = list()
         for filter in filters:
-            url: str = ""
+            url: UrlFilter = ""
             method: Any = None
             if isinstance(filter, tuple) and len(filter) == 2:
                 method = filter[0]

--- a/src/pyutils/throttledclientsession.py
+++ b/src/pyutils/throttledclientsession.py
@@ -66,7 +66,7 @@ class ThrottledClientSession(ClientSession):
         assert isinstance(rate_limit, (int, float)), "rate_limit has to be float"
         assert isinstance(filters, list), "filters has to be list"
         assert isinstance(limit_filtered, bool), "limit_filtered has to be bool"
-        assert isinstance(re_filter, bool), "re_filter has to be bool"
+        # assert isinstance(re_filter, bool), "re_filter has to be bool"
 
         super().__init__(*args, **kwargs)
 
@@ -80,27 +80,28 @@ class ThrottledClientSession(ClientSession):
         self._count: int = 0
         self._errors: int = 0
         self._limit_filtered: bool = limit_filtered
+        # self._re_filter: bool = re_filter
         self._filters: list[Tuple[Optional[HTTPmethod], UrlFilter]] = list()
         for filter in filters:
             url: UrlFilter = ""
-            method: Any = None
+            method: str | None = None
             if isinstance(filter, tuple) and len(filter) == 2:
                 method = filter[0]
                 url = filter[1]
-            elif isinstance(filter, str):
+            elif isinstance(filter, str) or isinstance(filter, re.Pattern):
                 url = filter
             self.add_filter(filter=url, method=method)
 
         self._set_limit()
 
-    def add_filter(self, filter: str, method: str | None = None):
+    def add_filter(self, filter: str | re.Pattern, method: str | None = None):
         """Add a filter to filter list"""
         if not (method is None or is_HTTP_method(method=method)):
             raise ValueError(f"'method' is not None or a valid HTTP method: {method}")
-        if self._re_filter:
-            self._filters.append((method, re.compile(filter)))
-        else:
-            self._filters.append((method, filter))
+        # if self._re_filter:
+        #     self._filters.append((method, re.compile(filter)))
+        # else:
+        self._filters.append((method, filter))
 
     @deprecated(version="1.1.0", reason="Use 'rate' property instead")
     def get_rate(self) -> float:

--- a/src/pyutils/utils.py
+++ b/src/pyutils/utils.py
@@ -270,7 +270,10 @@ async def post_url(
         debug(f"POST {url}: try {retry} / {retries}")
         try:
             async with session.post(
-                url, headers=headers, data=data, **kwargs  # chunked=512 * 1024,
+                url,
+                headers=headers,
+                data=data,
+                **kwargs,  # chunked=512 * 1024,
             ) as resp:
                 debug(f"POST {url} HTTP response status {resp.status}/{resp.reason}")
                 if resp.ok:

--- a/tests/test_asyncqueue.py
+++ b/tests/test_asyncqueue.py
@@ -1,6 +1,4 @@
-import sys
 import pytest  # type: ignore
-from pathlib import Path
 from queue import Queue
 
 # from asyncio.queues import QueueEmpty, QueueFull
@@ -14,9 +12,7 @@ from asyncio import (
     QueueFull,
 )
 
-sys.path.insert(0, str(Path(__file__).parent.parent.resolve() / "src"))
-
-from pyutils import AsyncQueue  # noqa: E402
+from pyutils import AsyncQueue
 
 QSIZE: int = 10
 N: int = 100  # N >> QSIZE

--- a/tests/test_bucketmapper.py
+++ b/tests/test_bucketmapper.py
@@ -1,12 +1,8 @@
-import sys
 import pytest  # type: ignore
 from dataclasses import dataclass
 from random import randrange
-from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent.parent.resolve() / "src"))
-
-from pyutils import BucketMapper  # noqa: E402
+from pyutils import BucketMapper
 
 ########################################################
 #

--- a/tests/test_eventcounter.py
+++ b/tests/test_eventcounter.py
@@ -1,10 +1,6 @@
-import sys
 import pytest  # type: ignore
-from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent.parent.resolve() / "src"))
-
-from pyutils import EventCounter  # noqa: E402
+from pyutils import EventCounter
 
 
 ########################################################

--- a/tests/test_filequeue.py
+++ b/tests/test_filequeue.py
@@ -1,21 +1,16 @@
-import sys
 import pytest  # type: ignore
 from pathlib import Path
 from os import makedirs
 from fnmatch import fnmatch, fnmatchcase
 import logging
 
+from pyutils import FileQueue
 
 logger = logging.getLogger()
 error = logger.error
 message = logger.warning
 verbose = logger.info
 debug = logger.debug
-
-sys.path.insert(0, str(Path(__file__).parent.parent.resolve() / "src"))
-
-from pyutils import FileQueue  # noqa: E402
-
 ########################################################
 #
 # Test Plan

--- a/tests/test_iterablequeue.py
+++ b/tests/test_iterablequeue.py
@@ -1,6 +1,4 @@
-import sys
 import pytest  # type: ignore
-from pathlib import Path
 from asyncio.queues import QueueEmpty, QueueFull
 from asyncio import (
     Task,
@@ -13,9 +11,7 @@ from asyncio import (
 )
 from random import random
 
-sys.path.insert(0, str(Path(__file__).parent.parent.resolve() / "src"))
-
-from pyutils import IterableQueue, QueueDone  # noqa: E402
+from pyutils import IterableQueue, QueueDone
 
 QSIZE: int = 10
 N: int = 100  # N >> QSIZE

--- a/tests/test_throttledclientsession.py
+++ b/tests/test_throttledclientsession.py
@@ -11,8 +11,9 @@ from socketserver import ThreadingMixIn
 from asyncio import sleep
 import logging
 import json
+import re
 
-from pyutils import ThrottledClientSession
+from pyutils import ThrottledClientSession, UrlFilter
 from pyutils.utils import epoch_now, get_url_JSON
 
 
@@ -27,26 +28,22 @@ N_SLOW: int = 3
 
 THREADS: int = 5
 
-FILTERS: List[str | Tuple[Optional[str], str]] = [
+FILTERS: List[UrlFilter | Tuple[Optional[str], UrlFilter]] = [
     "http://localhost",
     (None, "http://local"),
     ("GET", "http://localhost"),
-]
-FILTERS_RE: List[str | Tuple[Optional[str], str]] = [
-    ".*localhost",
-    (None, "http://local"),
-    ("GET", ".+/localhost"),
+    re.compile(".*localhost"),
+    (None, re.compile("http://local")),
+    ("GET", re.compile(".+/localhost")),
 ]
 
-FILTERS_FAIL: List[str | Tuple[Optional[str], str]] = [
+FILTERS_FAIL: List[UrlFilter | Tuple[Optional[str], UrlFilter]] = [
     "http://notworking",
     (None, "http://notworking"),
     ("POST", "http://localhost"),
-]
-FILTERS_RE_FAIL: List[str | Tuple[Optional[str], str]] = [
-    "notworking",
-    (None, "http://notworking"),
-    ("POST", ".+/localhost"),
+    re.compile("^notwork.+ing"),
+    (None, re.compile("http://notworking")),
+    ("POST", re.compile(".+/localhost")),
 ]
 
 # N : int = int(1e10)
@@ -439,7 +436,7 @@ async def test_3_get_json(server_url: str, json_path: str) -> None:
 async def test_4_filters(
     server_url: str,
     limit_filtered: bool,
-    filter: str | Tuple[Optional[str], str],
+    filter: UrlFilter | Tuple[Optional[str], UrlFilter],
 ) -> None:
     """Test timings of N/sec get"""
     rate_limit: float = RATE_SLOW
@@ -475,51 +472,51 @@ async def test_4_filters(
                                             {', '.join([str(t) for t in timings])}"""
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="not supported on windows: asyncio.loop.create_unix_connection",
-)
-@pytest.mark.timeout(60)
-@pytest.mark.asyncio
-@pytest.mark.parametrize("limit_filtered,filter", product([True, False], FILTERS_RE))
-async def test_5_filters_regexp(
-    server_url: str,
-    limit_filtered: bool,
-    filter: str | Tuple[Optional[str], str],
-) -> None:
-    """Test timings of N/sec get"""
-    rate_limit: float = RATE_SLOW
-    N: int = N_SLOW
-    await sleep(2)  # wait the server to start
-    timings: list[float] = await _get(
-        server_url,
-        rate=rate_limit,
-        N=N,
-        limit_filtered=limit_filtered,
-        filters=[filter],
-        re_filter=True,
-    )
-    rate_max: float = max_rate(timings, rate_limit)
-    rate_avg: float = avg_rate(timings)
-    message(
-        f"rate limit: {rate_limit:.2f}, avg rate: {rate_avg:.2f}, max rate: {rate_max:.2f}"
-    )
-    if limit_filtered:
-        assert (
-            rate_avg <= rate_limit * 1.05
-        ), f"Avg. rate is above rate_limit: {rate_avg:.2f} > {rate_limit:.2f}"
-        assert (
-            rate_max <= rate_limit * 1.1
-        ), f""""max_rate is above rate_limit: {rate_max:.2f} > {rate_limit:.2f}\n
-                                            {', '.join([str(t) for t in timings])}"""
-    else:
-        assert (
-            rate_avg > rate_limit * 2
-        ), f"request are rate_limited even limit_filtered={limit_filtered}: {rate_avg:.2f} > {rate_limit:.2f}"
-        assert (
-            rate_max > rate_limit * 2
-        ), f"""request are rate_limited even limit_filtered={limit_filtered}: {rate_max:.2f} > {rate_limit:.2f}\n
-                                            {', '.join([str(t) for t in timings])}"""
+# @pytest.mark.skipif(
+#     sys.platform == "win32",
+#     reason="not supported on windows: asyncio.loop.create_unix_connection",
+# )
+# @pytest.mark.timeout(60)
+# @pytest.mark.asyncio
+# @pytest.mark.parametrize("limit_filtered,filter", product([True, False], FILTERS_RE))
+# async def test_5_filters_regexp(
+#     server_url: str,
+#     limit_filtered: bool,
+#     filter: str | Tuple[Optional[str], str],
+# ) -> None:
+#     """Test timings of N/sec get"""
+#     rate_limit: float = RATE_SLOW
+#     N: int = N_SLOW
+#     await sleep(2)  # wait the server to start
+#     timings: list[float] = await _get(
+#         server_url,
+#         rate=rate_limit,
+#         N=N,
+#         limit_filtered=limit_filtered,
+#         filters=[filter],
+#         re_filter=True,
+#     )
+#     rate_max: float = max_rate(timings, rate_limit)
+#     rate_avg: float = avg_rate(timings)
+#     message(
+#         f"rate limit: {rate_limit:.2f}, avg rate: {rate_avg:.2f}, max rate: {rate_max:.2f}"
+#     )
+#     if limit_filtered:
+#         assert (
+#             rate_avg <= rate_limit * 1.05
+#         ), f"Avg. rate is above rate_limit: {rate_avg:.2f} > {rate_limit:.2f}"
+#         assert (
+#             rate_max <= rate_limit * 1.1
+#         ), f""""max_rate is above rate_limit: {rate_max:.2f} > {rate_limit:.2f}\n
+#                                             {', '.join([str(t) for t in timings])}"""
+#     else:
+#         assert (
+#             rate_avg > rate_limit * 2
+#         ), f"request are rate_limited even limit_filtered={limit_filtered}: {rate_avg:.2f} > {rate_limit:.2f}"
+#         assert (
+#             rate_max > rate_limit * 2
+#         ), f"""request are rate_limited even limit_filtered={limit_filtered}: {rate_max:.2f} > {rate_limit:.2f}\n
+#                                             {', '.join([str(t) for t in timings])}"""
 
 
 @pytest.mark.skipif(
@@ -529,10 +526,10 @@ async def test_5_filters_regexp(
 @pytest.mark.timeout(60)
 @pytest.mark.asyncio
 @pytest.mark.parametrize("limit_filtered,filter", product([True, False], FILTERS_FAIL))
-async def test_6_filters_no_match(
+async def test_5_filters_no_match(
     server_url: str,
     limit_filtered: bool,
-    filter: str | Tuple[Optional[str], str],
+    filter: UrlFilter | Tuple[Optional[str], UrlFilter],
 ) -> None:
     """Test timings of N/sec get"""
     rate_limit: float = RATE_SLOW
@@ -569,53 +566,53 @@ async def test_6_filters_no_match(
                                             {', '.join([str(t) for t in timings])}"""
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="not supported on windows: asyncio.loop.create_unix_connection",
-)
-@pytest.mark.timeout(60)
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "limit_filtered,filter", product([True, False], FILTERS_RE_FAIL)
-)
-async def test_7_filters_regexp_no_match(
-    server_url: str,
-    limit_filtered: bool,
-    filter: str | Tuple[Optional[str], str],
-) -> None:
-    """Test timings of N/sec get"""
-    rate_limit: float = RATE_SLOW
-    N: int = N_SLOW
-    await sleep(2)  # wait the server to start
-    timings: list[float] = await _get(
-        server_url,
-        rate=rate_limit,
-        N=N,
-        limit_filtered=limit_filtered,
-        filters=[filter],
-        re_filter=True,
-    )
-    rate_max: float = max_rate(timings, rate_limit)
-    rate_avg: float = avg_rate(timings)
-    message(
-        f"rate limit: {rate_limit:.2f}, avg rate: {rate_avg:.2f}, max rate: {rate_max:.2f}"
-    )
-    if not limit_filtered:
-        assert (
-            rate_avg <= rate_limit * 1.05
-        ), f"Avg. rate is above rate_limit: {rate_avg:.2f} > {rate_limit:.2f}"
-        assert (
-            rate_max <= rate_limit * 1.1
-        ), f""""max_rate is above rate_limit: {rate_max:.2f} > {rate_limit:.2f}\n
-                                            {', '.join([str(t) for t in timings])}"""
-    else:
-        assert (
-            rate_avg > rate_limit * 2
-        ), f"request are rate_limited even limit_filtered={limit_filtered}: {rate_avg:.2f} > {rate_limit:.2f}"
-        assert (
-            rate_max > rate_limit * 2
-        ), f"""request are rate_limited even limit_filtered={limit_filtered}: {rate_max:.2f} > {rate_limit:.2f}\n
-                                            {', '.join([str(t) for t in timings])}"""
+# @pytest.mark.skipif(
+#     sys.platform == "win32",
+#     reason="not supported on windows: asyncio.loop.create_unix_connection",
+# )
+# @pytest.mark.timeout(60)
+# @pytest.mark.asyncio
+# @pytest.mark.parametrize(
+#     "limit_filtered,filter", product([True, False], FILTERS_RE_FAIL)
+# )
+# async def test_7_filters_regexp_no_match(
+#     server_url: str,
+#     limit_filtered: bool,
+#     filter: str | Tuple[Optional[str], str],
+# ) -> None:
+#     """Test timings of N/sec get"""
+#     rate_limit: float = RATE_SLOW
+#     N: int = N_SLOW
+#     await sleep(2)  # wait the server to start
+#     timings: list[float] = await _get(
+#         server_url,
+#         rate=rate_limit,
+#         N=N,
+#         limit_filtered=limit_filtered,
+#         filters=[filter],
+#         re_filter=True,
+#     )
+#     rate_max: float = max_rate(timings, rate_limit)
+#     rate_avg: float = avg_rate(timings)
+#     message(
+#         f"rate limit: {rate_limit:.2f}, avg rate: {rate_avg:.2f}, max rate: {rate_max:.2f}"
+#     )
+#     if not limit_filtered:
+#         assert (
+#             rate_avg <= rate_limit * 1.05
+#         ), f"Avg. rate is above rate_limit: {rate_avg:.2f} > {rate_limit:.2f}"
+#         assert (
+#             rate_max <= rate_limit * 1.1
+#         ), f""""max_rate is above rate_limit: {rate_max:.2f} > {rate_limit:.2f}\n
+#                                             {', '.join([str(t) for t in timings])}"""
+#     else:
+#         assert (
+#             rate_avg > rate_limit * 2
+#         ), f"request are rate_limited even limit_filtered={limit_filtered}: {rate_avg:.2f} > {rate_limit:.2f}"
+#         assert (
+#             rate_max > rate_limit * 2
+#         ), f"""request are rate_limited even limit_filtered={limit_filtered}: {rate_max:.2f} > {rate_limit:.2f}\n
+#                                             {', '.join([str(t) for t in timings])}"""
 
 
 # @pytest.mark.timeout(10)

--- a/tests/test_throttledclientsession.py
+++ b/tests/test_throttledclientsession.py
@@ -1,6 +1,5 @@
 import sys
 import pytest  # type: ignore
-from pathlib import Path
 from datetime import datetime
 from itertools import pairwise, accumulate, product
 from functools import cached_property
@@ -13,11 +12,8 @@ from asyncio import sleep
 import logging
 import json
 
-
-sys.path.insert(0, str(Path(__file__).parent.parent.resolve() / "src"))
-
-from pyutils import ThrottledClientSession  # noqa: E402
-from pyutils.utils import epoch_now, get_url_JSON  # noqa: E402
+from pyutils import ThrottledClientSession
+from pyutils.utils import epoch_now, get_url_JSON
 
 
 HOST: str = "localhost"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,28 +1,23 @@
 from enum import Enum
 from math import ceil
-import sys
 from typing import Annotated, Optional, List, Sequence
 import pytest  # type: ignore
 from pathlib import Path
 import click
 from typer import Typer, Context, Option
-
 import logging
-
 import typer
 
-sys.path.insert(0, str(Path(__file__).parent.parent.resolve() / "src"))
-
-from pyutils.utils import (  # noqa: E402
-    ClickHelpGen,
+from pyutils.utils import (
     Countable,
+    ClickHelpGen,
     TyperHelpGen,
     chunker,
     is_valid_obj,
     get_type,
     get_subtype,
 )
-from pyutils import awrap  # noqa: E402
+from pyutils import awrap
 
 logger = logging.getLogger()
 error = logger.error


### PR DESCRIPTION
- filters are not given as `str` (matches from the beginning of the URL) or `re.Pattern` i.e. pre-compiled regexp.